### PR TITLE
fix: favicon in all pages

### DIFF
--- a/priv/pages/base.html.eex
+++ b/priv/pages/base.html.eex
@@ -7,12 +7,12 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
-    <link rel="icon" href="assets/icons/favicon.ico">
-    <link rel="icon" href="assets/icons/favicon-16x16.png" sizes="16x16">
-    <link rel="icon" href="assets/icons/favicon-32x32.png" sizes="32x32">
-    <link rel="icon" href="assets/icons/apple-touch-icon.png" sizes="180x180">
-    <link rel="icon" href="assets/icons/android-chrome-192x192.png" sizes="192x192">
-    <link rel="icon" href="assets/icons/android-chrome-512x512.png" sizes="512x512">
+    <link rel="icon" href="/assets/icons/favicon.ico">
+    <link rel="icon" href="/assets/icons/favicon-16x16.png" sizes="16x16">
+    <link rel="icon" href="/assets/icons/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" href="/assets/icons/apple-touch-icon.png" sizes="180x180">
+    <link rel="icon" href="/assets/icons/android-chrome-192x192.png" sizes="192x192">
+    <link rel="icon" href="/assets/icons/android-chrome-512x512.png" sizes="512x512">
     <style type="text/css">
     body {
         margin: 0;


### PR DESCRIPTION
Favicon was not being shown in post pages because the icon path wasn't correct.

Path was relative `assets/img.png` instead of `/assets/img.png`